### PR TITLE
use gbase64 on macos

### DIFF
--- a/import.sh
+++ b/import.sh
@@ -1,2 +1,8 @@
-echo -e "\e[33m$(git log -100 --pretty=format:"%H*#%an*#%ae*#%at*#%s"|base64 -w 0)\e[39m"
-echo -e '\n\e[32m↑\e[39m \e[1mDouble-click\e[0m to select, then \e[1mcopy/paste\e[0m it in Git History Editor\e[39m \e[32m↑\e[39m'
+if [[ "$OSTYPE" == "darwin"* ]]; then
+	gnubase64=gbase64
+else
+	gnubase64=base64
+fi
+
+echo -e "$(git log -100 --pretty=format:"%H*#%an*#%ae*#%at*#%s"|${gnubase64} -w 0)"
+echo -e 'Double-click to select, then copy/paste it in Git History Editor'

--- a/import.sh
+++ b/import.sh
@@ -1,8 +1,9 @@
 if [[ "$OSTYPE" == "darwin"* ]]; then
-	gnubase64=gbase64
+	gnubase64="base64"
+	command -v gbase64 > /dev/null 2>&1 && gnubase64="gbase64 -w0"
 else
-	gnubase64=base64
+	gnubase64="base64 -w 0"
 fi
 
-echo -e "$(git log -100 --pretty=format:"%H*#%an*#%ae*#%at*#%s"|${gnubase64} -w 0)"
+echo -e "$(git log -100 --pretty=format:"%H*#%an*#%ae*#%at*#%s"|${gnubase64})"
 echo -e 'Double-click to select, then copy/paste it in Git History Editor'


### PR DESCRIPTION
I'm using string substitution instead of bash alias because the `command` in `echo "$(command...)"` is executed inside another bash instance I guess, at least alias is not working in that `echo` statement.

also remove some weird characters

fix https://github.com/bokub/git-history-editor/issues/11